### PR TITLE
Remove cert parsing

### DIFF
--- a/core/http/Cargo.toml
+++ b/core/http/Cargo.toml
@@ -27,7 +27,6 @@ rustls = { version = "0.13", optional = true }
 dns-lookup = "0.9.1"
 untrusted = "0.6.1"
 webpki = "0.18.0-alpha4"
-openssl = "0.10.10"
 
 [dependencies.cookie]
 git = "https://github.com/alexcrichton/cookie-rs"

--- a/core/http/src/tls.rs
+++ b/core/http/src/tls.rs
@@ -47,7 +47,7 @@ pub fn find_valid_cert_for_peer<'a>(name: &'a str, certs: &'a [Certificate]) -> 
 /// ##Examples
 ///
 /// The following short snippet shows `MutualTlsUser` being used as a request guard in a handler to
-/// verify the client's certificate.
+/// verify the client's certificate and print its subject name.
 ///
 /// ```rust
 /// # #![feature(plugin, decl_macro)]
@@ -56,12 +56,40 @@ pub fn find_valid_cert_for_peer<'a>(name: &'a str, certs: &'a [Certificate]) -> 
 /// use rocket::http::tls::MutualTlsUser;
 ///
 /// #[get("/message")]
-/// fn message(mtls:MutualTlsUser) {
-///     println!("Authenticated client");
+/// fn message(mtls: MutualTlsUser) {
+///     println!("{}", mtls.subject_name());
 /// }
 ///
 /// # fn main() { }
 /// ```
 ///
 #[derive(Debug)]
-pub struct MutualTlsUser {}
+pub struct MutualTlsUser {
+    subject_name: String,
+}
+
+impl MutualTlsUser {
+    pub fn new(subject_name: &str) -> MutualTlsUser {
+        // NOTE: `subject_name` is not necessarily the subject name in the certificate,
+        // but it is the name for which the certificate was validated.
+        MutualTlsUser {
+            subject_name: subject_name.to_string()
+        }
+    }
+
+    /// Return the client's subject name.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # extern crate rocket;
+    /// use rocket::http::tls::MutualTlsUser;
+    ///
+    /// fn handler(mtls: MutualTlsUser) {
+    ///     let subject_name = mtls.subject_name();
+    /// }
+    /// ```
+    pub fn subject_name(&self) -> &str {
+        &self.subject_name
+    }
+}

--- a/core/http/src/tls.rs
+++ b/core/http/src/tls.rs
@@ -3,30 +3,14 @@ extern crate hyper_sync_rustls;
 extern crate dns_lookup;
 extern crate untrusted;
 extern crate webpki;
-extern crate openssl;
 extern crate time;
 
 pub use self::hyper_sync_rustls::{util, WrappedStream, ServerSession, TlsServer};
 pub use self::rustls::{Certificate, PrivateKey, RootCertStore, internal::pemfile};
 pub use self::dns_lookup::lookup_addr;
 
-use self::openssl::x509::X509;
-use self::time::{Tm, strptime, ParseError};
 use self::untrusted::Input;
 use self::webpki::{EndEntityCert, DNSNameRef};
-
-type DateTime = Tm;
-
-/// Convert openssl ASN.1 time to a `DateTime`
-fn asn1time_to_datetime(dt: &openssl::asn1::Asn1TimeRef) -> Result<DateTime, ParseError> {
-    // Sep  1 10:02:28 2017 GMT
-    let s = format!("{}", dt);
-    // strip GMT and any space-padding
-    let s = s.trim_right_matches(" GMT").replace("  ", " ");
-
-    let fmt = "%b %d %H:%M:%S %Y";
-    strptime(&s, fmt)
-}
 
 
 /// Find the first `Certificate` valid for the given DNS name
@@ -52,22 +36,18 @@ pub fn find_valid_cert_for_peer<'a>(name: &'a str, certs: &'a [Certificate]) -> 
     Ok(valid_cert)
 }
 
-/// Client MTLS certificate information.
+/// MTLS client authentication.
 ///
-/// The `MutualTlsUser` type specifies MTLS being required for the route and retrieves client
-/// certificate information.
+/// The `MutualTlsUser` type is a request guard that only allows properly authenticated clients.
 ///
 /// #Usage
 ///
 /// A `MutualTlsUser` can be retrieved via its `FromRequest` implementation as a request guard.
-/// Information of the certificate with a matching common name as a reverse DNS lookup of the
-/// client IP address from the accepted certificate chain can be retrieved via the
-/// `get_common_names`, `get_not_before`, and `get_not_after`.
 ///
 /// ##Examples
 ///
 /// The following short snippet shows `MutualTlsUser` being used as a request guard in a handler to
-/// verify the client's certificate and print the common names of the client.
+/// verify the client's certificate.
 ///
 /// ```rust
 /// # #![feature(plugin, decl_macro)]
@@ -77,93 +57,11 @@ pub fn find_valid_cert_for_peer<'a>(name: &'a str, certs: &'a [Certificate]) -> 
 ///
 /// #[get("/message")]
 /// fn message(mtls:MutualTlsUser) {
-///     let common_names = mtls.get_common_names();
-///     for name in common_names {
-///         println!("{}", name);
-///     }
+///     println!("Authenticated client");
 /// }
 ///
 /// # fn main() { }
 /// ```
 ///
 #[derive(Debug)]
-pub struct MutualTlsUser {
-    common_names: Vec<String>,
-    not_before: DateTime,
-    not_after: DateTime,
-}
-
-impl MutualTlsUser {
-    // TODO: return a Result
-    pub fn new(peer_cert: &Certificate) -> Option<MutualTlsUser> {
-        // Generate an x509 using the certificate provided
-        let x509 = X509::from_der(peer_cert.as_ref()).ok()?;
-
-        // Retrieve alt names and store them into a Vec<String>
-        let alt_names = x509.subject_alt_names()?;
-        let mut common_names = Vec::new();
-        for name in alt_names {
-            common_names.push(name.dnsname()?.to_string())
-        }
-
-        // Retrieve certificate start time
-        let not_before = asn1time_to_datetime(x509.not_before()).ok()?;
-
-        // Retrieve certificate end time
-        let not_after = asn1time_to_datetime(x509.not_after()).ok()?;
-
-        Some(MutualTlsUser {
-            common_names,
-            not_before,
-            not_after,
-        })
-    }
-
-    /// Return the client's common names.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # extern crate rocket;
-    /// use rocket::http::tls::MutualTlsUser;
-    ///
-    /// fn handler(mtls: MutualTlsUser) {
-    ///     let cert_common_names = mtls.get_common_names();
-    /// }
-    /// ```
-    pub fn get_common_names(&self) -> &[String] {
-        &self.common_names
-    }
-
-    /// Return the client's certificate's validity period start time.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # extern crate rocket;
-    /// use rocket::http::tls::MutualTlsUser;
-    ///
-    /// fn handler(mtls: MutualTlsUser) {
-    ///     let cert_start_time = mtls.get_not_before();
-    /// }
-    /// ```
-    pub fn get_not_before(&self) -> &DateTime {
-        &self.not_before
-    }
-
-    /// Return the client's certificate's validity period end time.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # extern crate rocket;
-    /// use rocket::http::tls::MutualTlsUser;
-    ///
-    /// fn handler(mtls: MutualTlsUser) {
-    ///     let cert_end_time = mtls.get_not_after();
-    /// }
-    /// ```
-    pub fn get_not_after(&self) -> &DateTime {
-        &self.not_after
-    }
-}
+pub struct MutualTlsUser {}

--- a/core/lib/src/config/builder.rs
+++ b/core/lib/src/config/builder.rs
@@ -227,13 +227,10 @@ impl ConfigBuilder {
     ///     .unwrap();
     /// # */
     /// ```
-    pub fn tls<C, K, W>(mut self, certs_path: C, key_path: K, cert_store_path: Option<W>) -> Self
-        where C: Into<String>, K: Into<String>, W: Into<String>
+    pub fn tls<C, K, W>(mut self, certs_path: C, key_path: K, cert_store_path: W) -> Self
+        where C: Into<String>, K: Into<String>, W: Into<Option<String>>
     {
-        self.tls = match cert_store_path {
-            Some(cert_store) => Some((certs_path.into(), key_path.into(), Some(cert_store.into()))),
-            None => Some((certs_path.into(), key_path.into(), None)),
-        };
+        self.tls = Some((certs_path.into(), key_path.into(), cert_store_path.into()));
         self
     }
 
@@ -339,10 +336,7 @@ impl ConfigBuilder {
         config.set_limits(self.limits);
 
         if let Some((certs_path, key_path, cert_store_path)) = self.tls {
-            match cert_store_path {
-                Some(cert_store) => config.set_tls(&certs_path, &key_path, Some(&cert_store))?,
-                None => config.set_tls(&certs_path, &key_path, None)?,
-            }
+            config.set_tls(&certs_path, &key_path, cert_store_path.as_ref().map(String::as_str))?;
         }
 
         if let Some(key) = self.secret_key {

--- a/core/lib/src/config/config.rs
+++ b/core/lib/src/config/config.rs
@@ -574,23 +574,23 @@ impl Config {
             })?;
 
         // Load certs for clients.
-        if cert_store_path == None {
+        if let Some(path) = cert_store_path {
+            let ca_cert_vector = util::load_cert_store_certs(self.root_relative(path))
+                .map_err(|e| match e {
+                    Error::Io(e) => ConfigError::Io(e, "tls.ca_certs"),
+                    _ => self.bad_type("tls", pem_err, "a valid certificate store directory")
+                })?;
+
+            let ca_certs = Some(util::generate_cert_store(ca_cert_vector)
+                .map_err(|e| match e {
+                    _ => self.bad_type("tls", pem_err, "a valid certificate store")
+                })?);
+
+            self.tls = Some(TlsConfig { certs, key, ca_certs });
+        } else {
             self.tls = Some(TlsConfig { certs, key, ca_certs: None });
-            return Ok(());
-        };
+        }
 
-        let ca_cert_vector = util::load_cert_store_certs(self.root_relative(cert_store_path.unwrap()))
-            .map_err(|e| match e {
-                Error::Io(e) => ConfigError::Io(e, "tls.ca_certs"),
-                _ => self.bad_type("tls", pem_err, "a valid certificate store directory")
-            })?;
-
-        let ca_certs = Some(util::generate_cert_store(ca_cert_vector)
-            .map_err(|e| match e {
-                _ => self.bad_type("tls", pem_err, "a valid certificate store")
-            })?);
-
-        self.tls = Some(TlsConfig { certs, key, ca_certs });
         Ok(())
     }
 

--- a/core/lib/src/config/custom_values.rs
+++ b/core/lib/src/config/custom_values.rs
@@ -243,10 +243,8 @@ pub fn tls_config<'v>(conf: &Config,
         }
     }
 
-    if let (Some(certs), Some(key), Some(ca_certs)) = (certs_path, key_path, cert_store_path) {
-        Ok((certs, key, Some(ca_certs)))
-    } else if let (Some(certs), Some(key), None) = (certs_path, key_path, cert_store_path) {
-        Ok((certs, key, None))
+    if let (Some(certs), Some(key)) = (certs_path, key_path) {
+        Ok((certs, key, cert_store_path))
     } else {
         Err(conf.bad_type(name, "a table with missing entries",
                             "a table with `certs` and `key` entries"))

--- a/core/lib/src/data/data.rs
+++ b/core/lib/src/data/data.rs
@@ -147,17 +147,16 @@ impl Data {
         };
 
         #[cfg(feature = "tls")]
-        let mut data = Data::new(http_stream);
-        #[cfg(feature = "tls")]
-        match cert_info {
-            Some(certs) => data.set_peer_certificates(certs),
-            None => ()
+        {
+            let mut data = Data::new(http_stream);
+            if let Some(certs) = cert_info {
+                data.set_peer_certificates(certs);
+            }
+            Ok(data)
         }
 
         #[cfg(not(feature = "tls"))]
-        let data = Data::new(http_stream);
-
-        Ok(data)
+        Ok(Data::new(http_stream))
     }
 
     /// Retrieve the `peek` buffer.

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -329,9 +329,9 @@ impl <'a, 'r> FromRequest<'a, 'r> for MutualTlsUser {
         let ip_addr = request.client_ip().or_forward(())?;
         let name = lookup_addr(&ip_addr).map_err(|_| ()).or_forward(())?;
 
-        // Create a MutualTlsUser from the first valid cert
-        let valid_cert = find_valid_cert_for_peer(&name, &certs).or_forward(())?;
+        // Validate the name against the provided certs and create a MutualTlsUser
+        find_valid_cert_for_peer(&name, &certs).or_forward(())?;
 
-        MutualTlsUser::new(valid_cert).or_forward(())
+        Success(MutualTlsUser {})
     }
 }

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -9,7 +9,7 @@ use outcome::Outcome::*;
 use http::{Status, ContentType, Accept, Method, Cookies};
 use http::uri::Uri;
 #[cfg(feature = "tls")]
-use http::tls::{lookup_addr, Input, EndEntityCert, DNSNameRef, MutualTlsUser};
+use http::tls::{lookup_addr, Input, Certificate, EndEntityCert, DNSNameRef, MutualTlsUser};
 
 /// Type alias for the `Outcome` of a `FromRequest` conversion.
 pub type Outcome<S, E> = outcome::Outcome<S, (Status, E), ()>;
@@ -319,53 +319,31 @@ impl <'a, 'r> FromRequest<'a, 'r> for MutualTlsUser {
     type Error = ();
 
     fn from_request(request: &'a Request<'r>) -> Outcome<Self, Self::Error> {
-        // Get peer's IP address
-        let ip_addr = match request.client_ip() {
-            Some(val) => val,
-            None => return Forward(())
-        };
+        // Verify the client's common name against the provided certificates
+        // Fail if we can't get the common name or no certificates match.
 
-        // Reverse DNS lookup the peer's IP address
-        let name = match lookup_addr(&ip_addr) {
-            Ok(val) => val,
-            Err(_) => return Forward(())
-        };
-
-        // Change name to DNSNameRef
-        let name = Input::from(name.as_bytes());
-        let common_name = match DNSNameRef::try_from_ascii(name) {
-            Ok(val) => val,
-            Err(_) => return Forward(())
-        };
-
-        // Get certificates the peer provided
-        let certs = match request.get_peer_certificates() {
-            Some(val) => val,
-            None => return Forward(())
-        };
-
-        // Iterate through the client certificates
-        let certs_copy = certs.clone();
-        for (index, cert) in certs_copy.iter().enumerate() {
-            let cert_input = Input::from(cert.as_ref());
-            let end_entity = match EndEntityCert::from(cert_input) {
-                Ok(val) => val,
-                Err(_) => return Forward(())
-            };
-
-            // Compare certificate is valid for DNS name
-            let _verification = match end_entity.verify_is_valid_for_dns_name(common_name) {
-                Ok(val) => val,
-                Err(_) => return Forward(())
-            };
-
-            // Parse certificate
-            let mtls_user = match MutualTlsUser::new(certs[index].clone()) {
-                Some(val) => val,
-                None => return Forward(())
-            };
-            return Success(mtls_user);
+        fn first_valid_cert<'a>(certs: &'a [Certificate], common_name: DNSNameRef) -> Option<&'a Certificate> {
+            certs.iter()
+                .find(|cert| {
+                    let cert_input = Input::from(cert.as_ref());
+                    EndEntityCert::from(cert_input)
+                        .and_then(|ee| ee.verify_is_valid_for_dns_name(common_name).map(|_| true))
+                        .unwrap_or(false)
+                })
         }
-        Forward(())
+
+        // Get peer's IP address
+        let ip_addr = request.client_ip().or_forward(())?;
+
+        // Reverse DNS lookup the peer's IP address to get a DNSNameRef
+        let name = lookup_addr(&ip_addr).ok().or_forward(())?;
+        let input = Input::from(name.as_bytes());
+        let common_name = DNSNameRef::try_from_ascii(input).ok().or_forward(())?;
+
+        // Create a MutualTlsUser from the first valid cert
+        let certs = request.get_peer_certificates().or_forward(())?;
+        let valid_cert = first_valid_cert(&certs, common_name).or_forward(())?;
+
+        MutualTlsUser::new(valid_cert).or_forward(())
     }
 }

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -8,8 +8,9 @@ use outcome::Outcome::*;
 
 use http::{Status, ContentType, Accept, Method, Cookies};
 use http::uri::Uri;
+
 #[cfg(feature = "tls")]
-use http::tls::{lookup_addr, Input, Certificate, EndEntityCert, DNSNameRef, MutualTlsUser};
+use http::tls::{lookup_addr, find_valid_cert_for_peer, MutualTlsUser};
 
 /// Type alias for the `Outcome` of a `FromRequest` conversion.
 pub type Outcome<S, E> = outcome::Outcome<S, (Status, E), ()>;
@@ -322,27 +323,14 @@ impl <'a, 'r> FromRequest<'a, 'r> for MutualTlsUser {
         // Verify the client's common name against the provided certificates
         // Fail if we can't get the common name or no certificates match.
 
-        fn first_valid_cert<'a>(certs: &'a [Certificate], common_name: DNSNameRef) -> Option<&'a Certificate> {
-            certs.iter()
-                .find(|cert| {
-                    let cert_input = Input::from(cert.as_ref());
-                    EndEntityCert::from(cert_input)
-                        .and_then(|ee| ee.verify_is_valid_for_dns_name(common_name).map(|_| true))
-                        .unwrap_or(false)
-                })
-        }
+        let certs = request.get_peer_certificates().or_forward(())?;
 
-        // Get peer's IP address
+        // Get peer's IP address and look up the DNS name
         let ip_addr = request.client_ip().or_forward(())?;
-
-        // Reverse DNS lookup the peer's IP address to get a DNSNameRef
-        let name = lookup_addr(&ip_addr).ok().or_forward(())?;
-        let input = Input::from(name.as_bytes());
-        let common_name = DNSNameRef::try_from_ascii(input).ok().or_forward(())?;
+        let name = lookup_addr(&ip_addr).map_err(|_| ()).or_forward(())?;
 
         // Create a MutualTlsUser from the first valid cert
-        let certs = request.get_peer_certificates().or_forward(())?;
-        let valid_cert = first_valid_cert(&certs, common_name).or_forward(())?;
+        let valid_cert = find_valid_cert_for_peer(&name, &certs).or_forward(())?;
 
         MutualTlsUser::new(valid_cert).or_forward(())
     }

--- a/core/lib/src/request/from_request.rs
+++ b/core/lib/src/request/from_request.rs
@@ -332,6 +332,6 @@ impl <'a, 'r> FromRequest<'a, 'r> for MutualTlsUser {
         // Validate the name against the provided certs and create a MutualTlsUser
         find_valid_cert_for_peer(&name, &certs).or_forward(())?;
 
-        Success(MutualTlsUser {})
+        Success(MutualTlsUser::new(&name))
     }
 }

--- a/examples/mtls/src/main.rs
+++ b/examples/mtls/src/main.rs
@@ -9,7 +9,7 @@ use rocket::http::tls::MutualTlsUser;
 
 #[get("/")]
 fn hello(mtls: MutualTlsUser) -> String {
-    format!("Hello, MTLS world, {:?}!", mtls)
+    format!("Hello, MTLS world, {}!", mtls.subject_name())
 }
 
 fn main() {

--- a/examples/mtls/src/main.rs
+++ b/examples/mtls/src/main.rs
@@ -9,8 +9,7 @@ use rocket::http::tls::MutualTlsUser;
 
 #[get("/")]
 fn hello(mtls: MutualTlsUser) -> String {
-    format!("Hello, {}!", mtls.get_common_names()[0])
-    // format!("{}", mtls.get_common_names()[0])
+    format!("Hello, MTLS world, {:?}!", mtls)
 }
 
 fn main() {

--- a/examples/mtls/src/tests.rs
+++ b/examples/mtls/src/tests.rs
@@ -35,5 +35,5 @@ fn hello_world() {
         .remote(socket)
         .dispatch();
 
-    assert_eq!(response.body_string(), Some("Hello, localhost!".into()));
+    assert_eq!(response.body_string(), Some("Hello, MTLS world, MutualTlsUser!".into()));
 }

--- a/examples/mtls/src/tests.rs
+++ b/examples/mtls/src/tests.rs
@@ -35,5 +35,5 @@ fn hello_world() {
         .remote(socket)
         .dispatch();
 
-    assert_eq!(response.body_string(), Some("Hello, MTLS world, MutualTlsUser!".into()));
+    assert_eq!(response.body_string(), Some("Hello, MTLS world, localhost!".into()));
 }


### PR DESCRIPTION
**Not to be merged yet!**

This addresses the stylistic comments for the MTLS pull request. In addition, it **removes** the certificate parsing, and therefore, the `openssl` dependency. However, it does expose the `subject_name` validated against the certificate (which could actually be a "subject alt name"). Ideally, we can create another PR later that exposes more certificate details.

We may also need to move the `webpki`, `untrusted` and `dns_lookup` dependent code into `hyper-sync-rustls`.